### PR TITLE
Fix - use corner of pixel coords

### DIFF
--- a/pyninjotiff/ninjotiff.py
+++ b/pyninjotiff/ninjotiff.py
@@ -247,10 +247,10 @@ def _get_projection_name(area_def):
 def _get_pixel_size(projection_name, area_def):
     		 
     if projection_name in ['PLAT', 'MERC',]:	
-      proj  = Proj(area_def.proj_dict)  			 
-      upper_left  = proj(area_def.area_extent[0], area_def.area_extent[3], inverse = True)
-      lower_right = proj(area_def.area_extent[2], area_def.area_extent[1], inverse = True)			 
-      pixel_size = abs(lower_right[0] - upper_left[0]) / area_def.shape[1] ,\
+        proj  = Proj(area_def.proj_dict)  			 
+        upper_left  = proj(area_def.area_extent[0], area_def.area_extent[3], inverse = True)
+        lower_right = proj(area_def.area_extent[2], area_def.area_extent[1], inverse = True)			 
+        pixel_size = abs(lower_right[0] - upper_left[0]) / area_def.shape[1] ,\
                    abs(upper_left[1] - lower_right[1]) / area_def.shape[0]
 		   
     elif projection_name in ('NPOL', 'SPOL',):

--- a/pyninjotiff/ninjotiff.py
+++ b/pyninjotiff/ninjotiff.py
@@ -243,23 +243,28 @@ def _get_projection_name(area_def):
     return None
 
 
-
 def _get_pixel_size(projection_name, area_def):
-    		 
-    if projection_name in ['PLAT', 'MERC',]:	
-        proj  = Proj(area_def.proj_dict)  			 
-        upper_left  = proj(area_def.area_extent[0], area_def.area_extent[3], inverse = True)
-        lower_right = proj(area_def.area_extent[2], area_def.area_extent[1], inverse = True)			 
-        pixel_size = abs(lower_right[0] - upper_left[0]) / area_def.shape[1] ,\
-                   abs(upper_left[1] - lower_right[1]) / area_def.shape[0]
-		   
+    if projection_name in ['PLAT', 'MERC', ]:
+        proj = Proj(area_def.proj_dict)
+        upper_left = proj(
+            area_def.area_extent[0],
+            area_def.area_extent[3],
+            inverse=True)
+        lower_right = proj(
+            area_def.area_extent[2],
+            area_def.area_extent[1],
+            inverse=True)
+        pixel_size = abs(lower_right[0] - upper_left[0]) / area_def.shape[1],\
+            abs(upper_left[1] - lower_right[1]) / area_def.shape[0]
+
     elif projection_name in ('NPOL', 'SPOL',):
-	a,b = proj4_radius_parameters(area_def.proj_dict)
+        a, b = proj4_radius_parameters(area_def.proj_dict)
         pixel_size = (np.rad2deg(area_def.pixel_size_x / a),
                       np.rad2deg(area_def.pixel_size_y / b))
     else:
-        raise ValueError("Could not determine pixel size from projection name '%s'" %
-                         projection_name + " (Unknown)")		   		 
+        raise ValueError(
+            "Could not determine pixel size from projection name '%s'" %
+            projection_name + " (Unknown)")
     return pixel_size
 
 
@@ -529,9 +534,14 @@ def write(image_data, output_fn, area_def, product_name=None, **kwargs):
     
 
     proj  = Proj(area_def.proj_dict) 
-    upper_left  = proj(area_def.area_extent[0], area_def.area_extent[3], inverse = True)
-    lower_right = proj(area_def.area_extent[2], area_def.area_extent[1], inverse = True)
-    
+    upper_left = proj(
+        area_def.area_extent[0],
+        area_def.area_extent[3],
+        inverse=True)
+    lower_right = proj(
+        area_def.area_extent[2],
+        area_def.area_extent[1],
+        inverse=True)    
  
     if len(image_data.shape) == 3:
         if image_data.shape[2] == 4:

--- a/pyninjotiff/ninjotiff.py
+++ b/pyninjotiff/ninjotiff.py
@@ -42,7 +42,9 @@ from copy import deepcopy
 from datetime import datetime
 
 import numpy as np
-from pyproj import Geod
+
+from pyproj import Proj
+from pyresample.utils import proj4_radius_parameters
 
 #import mpop.imageo.formats.writer_options as write_opts
 from pyninjotiff import tifffile
@@ -241,20 +243,23 @@ def _get_projection_name(area_def):
     return None
 
 
+
 def _get_pixel_size(projection_name, area_def):
-    if projection_name in ['PLAT', 'MERC']:
-        upper_left = area_def.get_lonlat(0, 0)
-        lower_right = area_def.get_lonlat(
-            area_def.shape[0] - 1, area_def.shape[1] - 1)
-        pixel_size = abs(lower_right[0] - upper_left[0]) / (area_def.shape[1] - 1),\
-            abs(upper_left[1] - lower_right[1]) / (area_def.shape[0] - 1)
-    elif projection_name in ('NPOL', 'SPOL'):
-        geod = Geod(**area_def.proj_dict)
-        pixel_size = (np.rad2deg(area_def.pixel_size_x / float(geod.a)),
-                      np.rad2deg(area_def.pixel_size_y / float(geod.b)))
+    		 
+    if projection_name in ['PLAT', 'MERC',]:	
+      proj  = Proj(area_def.proj_dict)  			 
+      upper_left  = proj(area_def.area_extent[0], area_def.area_extent[3], inverse = True)
+      lower_right = proj(area_def.area_extent[2], area_def.area_extent[1], inverse = True)			 
+      pixel_size = abs(lower_right[0] - upper_left[0]) / area_def.shape[1] ,\
+                   abs(upper_left[1] - lower_right[1]) / area_def.shape[0]
+		   
+    elif projection_name in ('NPOL', 'SPOL',):
+	a,b = proj4_radius_parameters(area_def.proj_dict)
+        pixel_size = (np.rad2deg(area_def.pixel_size_x / a),
+                      np.rad2deg(area_def.pixel_size_y / b))
     else:
-        raise ValueError("Could determine pixel size from projection name '%s'" %
-                         projection_name + " (Unknown)")
+        raise ValueError("Could not determine pixel size from projection name '%s'" %
+                         projection_name + " (Unknown)")		   		 
     return pixel_size
 
 
@@ -521,10 +526,13 @@ def write(image_data, output_fn, area_def, product_name=None, **kwargs):
         kwargs : dict
             See _write
     """
-    upper_left = area_def.get_lonlat(0, 0)
-    lower_right = area_def.get_lonlat(
-        area_def.shape[0] - 1, area_def.shape[1] - 1)
+    
 
+    proj  = Proj(area_def.proj_dict) 
+    upper_left  = proj(area_def.area_extent[0], area_def.area_extent[3], inverse = True)
+    lower_right = proj(area_def.area_extent[2], area_def.area_extent[1], inverse = True)
+    
+ 
     if len(image_data.shape) == 3:
         if image_data.shape[2] == 4:
             shape = (area_def.y_size, area_def.x_size, 4)
@@ -583,9 +591,11 @@ def write(image_data, output_fn, area_def, product_name=None, **kwargs):
             options['ref_lat2'] = 0
     if 'lon_0' in area_def.proj_dict:
         options['central_meridian'] = area_def.proj_dict['lon_0']
-    geod = Geod(**area_def.proj_dict)
-    options['radius_a'] = geod.a
-    options['radius_b'] = geod.b
+	
+
+    a,b = proj4_radius_parameters(area_def.proj_dict)
+    options['radius_a'] = a
+    options['radius_b'] = b
     options['origin_lon'] = upper_left[0]
     options['origin_lat'] = upper_left[1]
     options['min_gray_val'] = image_data.min()


### PR DESCRIPTION
Using corner of pixels for navigation instead of pixel center for better registration within ninjo
Using utility routine to obtain semi-major / semi-minor axis rather than custom code - cleaner