### PR TITLE
Calculate gradient and offset values from satpy stretching data

### DIFF
--- a/pyninjotiff/ninjotiff.py
+++ b/pyninjotiff/ninjotiff.py
@@ -356,8 +356,6 @@ def _finalize(img, dtype=np.uint8, value_range_measurement_unit=None,
             log.debug("Forcing fill value to %s", fill_value)
 
         data = img.data
-        #data = img.finalize(dtype=dtype, fill_value=fill_value)
-        #data = data[0].to_masked_array()
 
         fill_value = fill_value if fill_value is not None else np.iinfo(dtype).min
         log.debug("Entry xarray: %.2f, %.2f, %.2f" %
@@ -397,16 +395,8 @@ def _finalize(img, dtype=np.uint8, value_range_measurement_unit=None,
         
         data = (1 + ((data-offset_val) / scale_val)).astype(dtype)
 
-        #data = all(data) if all(data) < 256 else 255
-        #data = ((data-offset_val) / scale_val).astype(dtype)
-
         log.debug("After scaling: %.2f, %.2f, %.2f" %
                   (data.min(), data.mean(), data.max()))
-        #data = img.finalize(dtype=dtype, fill_value=fill_value)
-        #data = data.to_masked_array()
-        #mask = data.mask
-        #data[mask] = fill_value
-
 
         return data[0], scale, offset, fill_value
 

--- a/pyninjotiff/ninjotiff.py
+++ b/pyninjotiff/ninjotiff.py
@@ -415,7 +415,7 @@ def _finalize(img, dtype=np.uint8, value_range_measurement_unit=None,
         # PFE: mpop.satout.cfscene
         if isinstance(img, np.ma.MaskedArray):
             data = img.channels[0]
-        else:
+        else :
             # TODO: check what is the corret fill value for NinJo!
             if fill_value is not None:
                 log.debug("Forcing fill value to %s", fill_value)
@@ -449,7 +449,7 @@ def _finalize(img, dtype=np.uint8, value_range_measurement_unit=None,
 
                 # Make room for transparent pixel.
                 scale_fill_value = (
-                        (np.iinfo(dtype).max) / (np.iinfo(dtype).max + 1.0))
+                    (np.iinfo(dtype).max) / (np.iinfo(dtype).max + 1.0))
                 img = deepcopy(img)
                 img.channels[0] *= scale_fill_value
 

--- a/pyninjotiff/ninjotiff.py
+++ b/pyninjotiff/ninjotiff.py
@@ -391,10 +391,9 @@ def _finalize(img, dtype=np.uint8, value_range_measurement_unit=None,
                   (data.min(), data.mean(), data.max()))
 
 
-        #vg: problem of values 0 if data is 256
         scale_fill = ((np.iinfo(dtype).max) / (np.iinfo(dtype).max + 1.0))
         data *= scale_fill
-        #end vg
+        
         data = (1 + ((data-offset_val) / scale_val)).astype(dtype)
 
         #data = all(data) if all(data) < 256 else 255


### PR DESCRIPTION
Add "use_value_range" mode, activated from ninjo configuration:

If use_value_range is set, gradient and offset ninjo values are calculated using satpy stretching values.
satpy stretching values are stored in output_info attribute of the xrimage.


This pyninjotiff version needs trollimage and satpy modification to store stretching values in output_info data