### PR TITLE
Unlock versions for dask and xarray

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,10 +17,10 @@ classifiers = [
 [tool.poetry.dependencies]
 python = "^3.7"
 numpy = ">=1.6"
-pyproj = "^3.2.1"
+pyproj = "*"
 pyresample = "^1.21.1"
-dask = {extras = ["array"], version = "^2021.9.1"}
-xarray = "^0.19.0"
+dask = {extras = ["array"], version = "*"}
+xarray = "*"
 trollimage = "^1.15.1"
 
 [tool.poetry.dev-dependencies]


### PR DESCRIPTION
Versions for xarray and dask now follow the year.month.number pattern, which does not work well with ^